### PR TITLE
Pass a feature-flag to increase unrolling limit

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -11,4 +11,7 @@ repository = "https://github.com/debris/ethbloom"
 [dependencies]
 tiny-keccak = "1.3"
 rustc-hex = "1.0"
-crunchy = "0.1"
+
+[dependencies.crunchy]
+version = "0.1"
+features = ["limit_256"]


### PR DESCRIPTION
Crunchy `0.1.6` by default doesn't allow 256-depth loops unrolling.
Most likely @Vurich will yank that `0.1.6` version and re-upload it as `0.2.0` since this is a breaking change; but explicitly enabling longer unrolling is a fix to make latest `ethbloom` build again.