### PR TITLE
No manual unrolling for 256-length loops

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -11,4 +11,7 @@ repository = "https://github.com/debris/ethbloom"
 [dependencies]
 tiny-keccak = "1.3"
 rustc-hex = "1.0"
-crunchy = "0.1"
+
+[dependencies.crunchy]
+version = "0.1"
+features = ["limit_256"]

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/debris/ethbloom"
 tiny-keccak = "1.3"
 rustc-hex = "1.0"
 
+[dev-dependencies]
+rand = "0.3"
+
 [dependencies.crunchy]
 version = "0.1"
 features = ["limit_256"]

--- a/ethbloom/benches/unrolling.rs
+++ b/ethbloom/benches/unrolling.rs
@@ -1,61 +1,73 @@
 #![feature(test)]
 
 extern crate test;
+extern crate rand;
 
 #[macro_use]
 extern crate crunchy;
 
-use test::Bencher;
+use test::{Bencher, black_box};
+use rand::Rng;
+
+fn random_data() -> [u8; 256] {
+	let mut res = [0u8; 256];
+	rand::thread_rng().fill_bytes(&mut res);
+	res
+}
 
 #[bench]
 fn forwards_with_crunchy(b: &mut Bencher) {
-	let mut data = [0u8; 256];
-	let other_data = [1u8; 256];
-
+	let mut data = random_data();
 	b.iter(|| {
+		let other_data = random_data();
 		unroll! {
-				for i in 0..255 {
-					data[i] |= other_data[i];
-				}
+			for i in 0..255 {
+				data[i] |= other_data[i];
 			}
-	})
+		}
+	});
+
+	black_box(data);
 }
 
 #[bench]
 fn backwards_with_crunchy(b: &mut Bencher) {
-	let mut data = [0u8; 256];
-	let other_data = [1u8; 256];
-
+	let mut data = random_data();
 	b.iter(|| {
+		let other_data = random_data();
 		unroll! {
-				for i in 0..255 {
-					data[255-i] |= other_data[255-i];
-				}
+			for i in 0..255 {
+				data[255-i] |= other_data[255-i];
 			}
-	})
+		}
+	});
+
+	black_box(data);
 }
 
 
 #[bench]
 fn forwards_without_crunchy(b: &mut Bencher) {
-	let mut data = [0u8; 256];
-	let other_data = [1u8; 256];
-
+	let mut data = random_data();
 	b.iter(|| {
+		let other_data = random_data();
 		for i in 0..255 {
 			data[i] |= other_data[i];
 		}
-	})
+	});
+
+	black_box(data);
 }
 
 #[bench]
 fn backwards_without_crunchy(b: &mut Bencher) {
-	let mut data = [0u8; 256];
-	let other_data = [1u8; 256];
-
+	let mut data = random_data();
 	b.iter(|| {
+		let other_data = random_data();
 		for i in 0..255 {
 			data[255-i] |= other_data[255-i];
 		}
-	})
+	});
+
+	black_box(data);
 }

--- a/ethbloom/benches/unrolling.rs
+++ b/ethbloom/benches/unrolling.rs
@@ -1,0 +1,61 @@
+#![feature(test)]
+
+extern crate test;
+
+#[macro_use]
+extern crate crunchy;
+
+use test::Bencher;
+
+#[bench]
+fn forwards_with_crunchy(b: &mut Bencher) {
+	let mut data = [0u8; 256];
+	let other_data = [1u8; 256];
+
+	b.iter(|| {
+		unroll! {
+				for i in 0..255 {
+					data[i] |= other_data[i];
+				}
+			}
+	})
+}
+
+#[bench]
+fn backwards_with_crunchy(b: &mut Bencher) {
+	let mut data = [0u8; 256];
+	let other_data = [1u8; 256];
+
+	b.iter(|| {
+		unroll! {
+				for i in 0..255 {
+					data[255-i] |= other_data[255-i];
+				}
+			}
+	})
+}
+
+
+#[bench]
+fn forwards_without_crunchy(b: &mut Bencher) {
+	let mut data = [0u8; 256];
+	let other_data = [1u8; 256];
+
+	b.iter(|| {
+		for i in 0..255 {
+			data[i] |= other_data[i];
+		}
+	})
+}
+
+#[bench]
+fn backwards_without_crunchy(b: &mut Bencher) {
+	let mut data = [0u8; 256];
+	let other_data = [1u8; 256];
+
+	b.iter(|| {
+		for i in 0..255 {
+			data[255-i] |= other_data[255-i];
+		}
+	})
+}

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -236,10 +236,8 @@ impl Bloom {
 		let bloom_ref: BloomRef = bloom.into();
 		assert_eq!(self.data.len(), 256);
 		assert_eq!(bloom_ref.data.len(), 256);
-		unroll! {
-			for i in 0..256 {
-				self.data[255 - i] |= bloom_ref.data[255 - i];
-			}
+		for i in 0..256 {
+			self.data[i] |= bloom_ref.data[i];
 		}
 	}
 
@@ -267,13 +265,11 @@ impl<'a> BloomRef<'a> {
 		let bloom_ref: BloomRef = bloom.into();
 		assert_eq!(self.data.len(), 256);
 		assert_eq!(bloom_ref.data.len(), 256);
-		unroll! {
-			for i in 0..256 {
-				let a = self.data[255 - i];
-				let b = bloom_ref.data[255 - i];
-				if (a & b) != b {
-					return false;
-				}
+		for i in 0..256 {
+			let a = self.data[i];
+			let b = bloom_ref.data[i];
+			if (a & b) != b {
+				return false;
 			}
 		}
 		true
@@ -305,8 +301,8 @@ mod tests {
 	use rustc_hex::FromHex;
 	use {Bloom, Input};
 
-    #[test]
-    fn it_works() {
+	#[test]
+	fn it_works() {
 		let bloom: Bloom = "00000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002020000000000000000000000000000000000000000000008000000001000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".into();
 		let address = "ef2d6d194084c2de36e0dabfce45d046b37d1106".from_hex().unwrap();
 		let topic = "02c69be41d0b7e40352fc85be1cd65eb03d40ef8427a0ca4596b1ead9a00e9fc".from_hex().unwrap();
@@ -323,5 +319,5 @@ mod tests {
 		assert!(my_bloom.contains(Input::Raw(&address)));
 		assert!(my_bloom.contains(Input::Raw(&topic)));
 		assert_eq!(my_bloom, bloom);
-    }
+	}
 }


### PR DESCRIPTION
As a followup for #1, I decided to bench @Vurich assumption that 256-length unrolling is just too much and will only make things worse by busting the caches.

I've started by adding benchmarks, which showed me the following (please note that the `limit_256` feature flag is still required):
```
test backwards_with_crunchy    ... bench:         284 ns/iter (+/- 23)
test backwards_without_crunchy ... bench:          38 ns/iter (+/- 2)
test forwards_with_crunchy     ... bench:         288 ns/iter (+/- 54)
test forwards_without_crunchy  ... bench:          26 ns/iter (+/- 4)
```

So let's use the usual forward-facing loop here, and rely on compiler to do it's vectorization magic.