### PR TITLE
Implement HeapSizeOf for Bloom

### DIFF
--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethbloom"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 description = "Ethereum bloom filter"
 license = "MIT"

--- a/ethbloom/Cargo.toml
+++ b/ethbloom/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/debris/ethbloom"
 [dependencies]
 tiny-keccak = "1.3"
 rustc-hex = "1.0"
+heapsize = { version = "0.4", optional = true }
 
 [dev-dependencies]
 rand = "0.3"
@@ -18,3 +19,6 @@ rand = "0.3"
 [dependencies.crunchy]
 version = "0.1"
 features = ["limit_256"]
+
+[features]
+heapsizeof = ["heapsize"]

--- a/ethbloom/src/lib.rs
+++ b/ethbloom/src/lib.rs
@@ -31,6 +31,10 @@ extern crate rustc_hex;
 #[macro_use]
 extern crate crunchy;
 
+#[cfg(feature="heapsizeof")]
+#[macro_use]
+extern crate heapsize;
+
 use std::{ops, fmt, mem, str};
 use tiny_keccak::keccak256;
 use rustc_hex::{ToHex, FromHex, FromHexError};
@@ -120,6 +124,8 @@ impl PartialEq for Bloom {
 		s_ref.eq(o_ref)
 	}
 }
+
+impl Eq for Bloom {}
 
 impl<'a> PartialEq<BloomRef<'a>> for Bloom {
 	fn eq(&self, other: &BloomRef<'a>) -> bool {
@@ -295,6 +301,9 @@ impl<'a> From<&'a Bloom> for BloomRef<'a> {
 		}
 	}
 }
+
+#[cfg(feature="heapsizeof")]
+known_heap_size!(0, Bloom);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
So, I happen to also need HeapSizeOf for Bloom while removing all custom Bloom implementations from paritytech/parity.

I suppose this is also a good moment to bump the version and publish it to crates.io
Can you please take care of this?